### PR TITLE
add env variable to skip localhost connection check

### DIFF
--- a/nt-app/src/noita.js
+++ b/nt-app/src/noita.js
@@ -54,7 +54,7 @@ class NoitaGame extends EventEmitter {
 
     isConnectionLocalhost(ws) {
         const addr = ws._socket.remoteAddress
-        return (addr == "::1") || (addr == "127.0.0.1") || (addr == "localhost") || (addr == "::ffff:127.0.0.1")
+        return (addr == "::1") || (addr == "127.0.0.1") || (addr == "localhost") || (addr == "::ffff:127.0.0.1") || process.env.DEBUG_NO_LOCALHOST_CHECK
     }
 
     gameListen() {


### PR DESCRIPTION
environment variable "DEBUG_NO_LOCALHOST_CHECK" will allow connections from non-localhost NT mod clients. only for testing in weird container environments :)