### PR TITLE
Prevent polymorphing before run start

### DIFF
--- a/noita_mod/core/files/scripts/utils.lua
+++ b/noita_mod/core/files/scripts/utils.lua
@@ -861,6 +861,16 @@ function StartRun()
             end
             ComponentSetValue2(controls_component, "enabled", true)
         end
+
+        --Remove polymorph immunity if we granted it pre-run-start
+        --So players cant polymorph and move around before run start
+        if (GameHasFlagRun("NT_added_poly_immune_prerun")) then
+            if(EntityHasTag(player, "polymorphable_NOT")) then
+                EntityRemoveTag(player, "polymorphable_NOT")
+            end
+            GameRemoveFlagRun("NT_added_poly_immune_prerun")
+        end
+
         local cosmetics = CosmeticFlags()
         SendWsEvent({event="CustomModEvent", payload={name="PlayerCosmeticFlags", flags=cosmetics}})
         GameAddFlagRun("NT_unlocked_controls")

--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -193,6 +193,13 @@ function OnPlayerSpawned(player_entity)
         ComponentSetValue2(controls_component, "enabled", false)
     end
 
+    --Prevent players from polymorphing before the run begins
+    --But don't add if we already have poly immunity from some other source (resumed run / reconnect while poly immune?)
+    if (not EntityHasTag(player_entity, "polymorphable_NOT")) then
+        EntityAddTag(player_entity, "polymorphable_NOT")
+        GameAddFlagRun("NT_added_poly_immune_prerun")
+    end
+
     if (ModSettingGet("noita-together.NT_HINTS")) then
         EntityLoad("mods/noita-together/files/entities/start_run_hint.xml", res_x - 45, res_y + 30)
     end


### PR DESCRIPTION
Adds `polymorphable_NOT` tag to player when spawned, then removes it when run starts.

Will do nothing if  player already has `polymorphable_NOT` for some reason or another.

This prevents players from polymorphing by drinking polymorphine (it's still drinkable) and moving around before the run is started.