### PR TITLE
Add command line arguments handling

### DIFF
--- a/nt-app/src/background.js
+++ b/nt-app/src/background.js
@@ -10,6 +10,7 @@ import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 import { updateMod } from "./update.js"
 const appEvent = require("./appEvent")
 const wsClient = require("./ws.js")
+const cmdLineArgs = require("./cmdLineArgs");
 const keytar = require("keytar")
 const got = require("got")
 const http = require("http")
@@ -118,6 +119,12 @@ async function createWindow() {
 }
 
 ipcMain.on("update_mod", (event, gamePath) => {
+    if(cmdLineArgs.isNoUpdate())
+    {
+        appEvent("skip_update", true)
+        return
+    }
+
     keytar.findCredentials("Noita Together").then(credentials => {
         if (credentials.length > 0) {
             const username = credentials[0].account

--- a/nt-app/src/cmdLineArgs.js
+++ b/nt-app/src/cmdLineArgs.js
@@ -1,0 +1,27 @@
+const { app } = require('electron')
+
+class CmdLineArgs {
+    constructor() {
+        this.offline = false
+        this.noUpdate = false
+        this.allowRemoteNoita = false
+
+        this.offline = app.commandLine.hasSwitch("nt-offline")
+        this.noUpdate = app.commandLine.hasSwitch("nt-noupdate")
+        this.allowRemoteNoita = app.commandLine.hasSwitch("nt-allow-remote-noita")
+    }
+
+    isOfflineMode() {
+        return this.offline
+    }
+
+    isNoUpdate() {
+        return this.noUpdate
+    }
+
+    isAllowRemoteNoita() {
+        return this.allowRemoteNoita
+    }
+}
+
+module.exports = new CmdLineArgs()

--- a/nt-app/src/noita.js
+++ b/nt-app/src/noita.js
@@ -3,6 +3,7 @@ const path = require("path")
 const ws = require("ws")
 const { v4: uuidv4 } = require("uuid")
 const appEvent = require("./appEvent")
+const cmdLineArgs = require("./cmdLineArgs");
 const { ipcMain } = require("electron")
 function sysMsg(message) {
     appEvent("sChat", {
@@ -54,7 +55,7 @@ class NoitaGame extends EventEmitter {
 
     isConnectionLocalhost(ws) {
         const addr = ws._socket.remoteAddress
-        return (addr == "::1") || (addr == "127.0.0.1") || (addr == "localhost") || (addr == "::ffff:127.0.0.1") || process.env.DEBUG_NO_LOCALHOST_CHECK
+        return (addr == "::1") || (addr == "127.0.0.1") || (addr == "localhost") || (addr == "::ffff:127.0.0.1") || cmdLineArgs.isAllowRemoteNoita()
     }
 
     gameListen() {

--- a/nt-app/src/views/Update.vue
+++ b/nt-app/src/views/Update.vue
@@ -35,6 +35,10 @@ export default {
         ipcRenderer.on("GAME_PATH_NOT_FOUND", () => {
             this.showPathModal = true
         })
+
+        ipcRenderer.on("skip_update", () => {
+            this.$router.replace({ path: "/login" })
+        })
     },
     created() {
         ipcRenderer.send("update_mod")


### PR DESCRIPTION
Adds a cmdLineArgs class with app-specific command line arguments
'--nt-noupdate' skips updater step, use at own risk
'--nt-offline' not implemented, for connecting to backend w/o twitch auth
'--nt-allow-remote-noita' replaces .env variable DEBUG_NO_LOCALHOST_CHECK