### PR TITLE
Fix banked wands with always casts gaining slots

### DIFF
--- a/noita_mod/core/files/scripts/spell_eater.lua
+++ b/noita_mod/core/files/scripts/spell_eater.lua
@@ -121,6 +121,9 @@ if (#wands > 0 and GameHasFlagRun("send_wands")) then
                     local action_id = ComponentGetValue2(item_component, "action_id")
                     if (is_always_cast) then
                         table.insert(always_cast, {id=action_id, usesRemaining=-1})
+                        --deck_capacity includes always casts, but for serialization *dont* count them
+                        --otherwise the wand gains slots when its deserialized and the ACs are added
+                        serialized.deck_capacity = serialized.deck_capacity - 1
                     else
                         table.insert(deck, {id=action_id, usesRemaining=uses_remaining})
                     end


### PR DESCRIPTION
Fixed an issue where banking a wand with always-casts would erroneously add that many slots to the wand.

This happened because the `deck_capacity` value includes the number of always casts, while the serialized value is intended to be the real wand capacity. Therefore deserialization would produce a wand with extra slots, *before* adding the always casts. This also affected display of the wand in the bank.