### PR TITLE
Add NT_is_host run flag when you are the lobby host

### DIFF
--- a/noita_mod/core/files/scripts/remove_flags.lua
+++ b/noita_mod/core/files/scripts/remove_flags.lua
@@ -1,4 +1,5 @@
 GameRemoveFlagRun("NT_GAMEMODE_CO_OP")
+GameRemoveFlagRun("NT_is_host")
 GameRemoveFlagRun("sync_steve")
 GameRemoveFlagRun("sync_hearts")
 GameRemoveFlagRun("sync_perks")

--- a/nt-app/src/noita.js
+++ b/nt-app/src/noita.js
@@ -180,6 +180,7 @@ class NoitaGame extends EventEmitter {
         const onDeathKick = data.some(entry => entry.flag == "_ondeath_kick")
         if (this.isHost) {
             this.onDeathKick = onDeathKick
+            data.push({ flag: "NT_is_host"})
         }
 
         data.push({ flag: "NT_GAMEMODE_CO_OP" })//hardcode this for now :) <3


### PR DESCRIPTION
Add a GameFlagRun "NT_is_host" when player is the lobby host. Can be seen by other noita mods and used for special integration such as theoretical synced TI. Maybe useful for host-only ingame NT core features?

Resolves #36