### PR TITLE
Tweak ws asyncloop

### DIFF
--- a/noita_mod/core/files/store.lua
+++ b/noita_mod/core/files/store.lua
@@ -26,4 +26,8 @@ if (NT.initialized ~= true) then
     NT.wsQueue = "[]"
     NT.queuedItems = "[]"
     NT.gold_queue = 0
+
+    --"Health Check" values for making sure we're running OK
+    NT.HealthCheck = {}
+    NT.HealthCheck.AsyncLoopLastFrame = -1
 end

--- a/noita_mod/core/files/ws/events.lua
+++ b/noita_mod/core/files/ws/events.lua
@@ -144,12 +144,20 @@ wsEvents = {
         PlayerList[data.userId].y = last.y
         PlayerList[data.userId].scale_x = last.scaleX
         MovePlayerGhost(data)
+        --update last-seen time
+        if PlayerList[data.userId].HealthCheck then
+            PlayerList[data.userId].HealthCheck.lastPosUpdate = GameGetFrameNum()
+        end
     end,
     PlayerPos = function(data)
         PlayerList[data.userId].x = data.x
         PlayerList[data.userId].y = data.y
         PlayerList[data.userId].scale_x = 1
         TeleportPlayerGhost(data)
+        --update last-seen time
+        if PlayerList[data.userId].HealthCheck then
+            PlayerList[data.userId].HealthCheck.lastPosUpdate = GameGetFrameNum()
+        end
     end,
     PlayerUpdate = function(data)
         if (PlayerList[data.userId] ~= nil) then
@@ -180,7 +188,9 @@ wsEvents = {
             userId = data.userId,
             location = "Mountain",
             sampo = false,
-            inven = {}
+            inven = {},
+            --reasonable start for health check values
+            HealthCheck = { lastPosUpdate = GameGetFrameNum() }
         }
         PlayerCount = PlayerCount + 1
         if (not HideGhosts) then

--- a/noita_mod/core/files/ws/ws.lua
+++ b/noita_mod/core/files/ws/ws.lua
@@ -81,8 +81,11 @@ _ws_main = function()
     increase_count()
 end
 last_wands = ""
+print_error("(NT:ws.lua) Start async_loop...")
 async_loop(function()
     if (NT ~= nil) then
+        --GamePrint("async tick (last " .. NT.HealthCheck.AsyncLoopLastFrame .. ")")
+        NT.HealthCheck.AsyncLoopLastFrame=GameGetFrameNum()
         local queue = json.decode(NT.wsQueue)
         for _, value in ipairs(queue) do
             SendWsEvent(value)

--- a/noita_mod/core/init.lua
+++ b/noita_mod/core/init.lua
@@ -244,4 +244,7 @@ function OnModPreInit()
     end
 end
 
-dofile("mods/noita-together/files/ws/ws.lua")
+function OnWorldInitialized()
+    --Moved this into OnWorldInitialized, it is inconsistent when included directly in init.lua 
+    dofile("mods/noita-together/files/ws/ws.lua")
+end


### PR DESCRIPTION
Move the ws.lua init into OnWorldInitialized - sometimes the async loop doesnt start and this makes it more consistent.

Also adds some health check variables for the ws async loop and player position updates that can be used elsewhere