### PR TITLE
First-pass spells charge display in bank

### DIFF
--- a/noita_mod/core/files/scripts/ui.lua
+++ b/noita_mod/core/files/scripts/ui.lua
@@ -296,6 +296,11 @@ if not initialized then
                 if (value.gameId ~= "0") then
                     GuiZSetForNextWidget(gui, 5)
                     GuiImage(gui, next_id(), nx + nox, ny + nyx, SpellSprites[value.gameId].sprite, 1, 0.8, 0.8)
+                    --This doesnt show charges if it was put in with unlimited spells, but it will come out full anyway
+                    --TODO this doesnt look nice because the text is large compared to the spell icons. Also its not the same font as used on vanilla spell icons
+                    if value.usesRemaining >= 0 then
+                        GuiText(gui, nx + nox + 1, ny + nyx - 8, value.usesRemaining)
+                    end
                     nox = nox + 15
                     if (index % 10 == 0) then
                         nyx = nyx + 20
@@ -317,6 +322,11 @@ if not initialized then
             local spell = SpellSprites[item.gameId]
             GuiImage(gui, next_id(), x +2, y +2,  spell.sprite, 1,1,1)--SpellSprites[item.gameId], 1)
             GuiTooltip(gui, spell.name, spell_description)
+            --This doesnt show charges if it was put in with unlimited spells, but it will come out full anyway
+            --TODO this is not the same font as used on vanilla spell icons???
+            if item.usesRemaining >= 0 then
+                GuiText(gui, x+1, y, item.usesRemaining)
+            end
         elseif (item.stats ~= nil) then --wand
             local nx, ny = (screen_width / 2) - 260, (screen_height/2) - 95
             render_wand(item, x, y, nx, ny, true)      


### PR DESCRIPTION
Here is a first pass at showing spell charges in the bank. Caveats:

The font isn't the same as that used for displaying charges on spell cards. For spells, this isn't that big of a deal.

However, the current tooltip for wands renders the spell icons smaller, so the font is a bit too large. This is compounded with the font used being larger than the normal spell card font. As it stands, putting the charges above the spells is readable, albeit not too visually nice, so it could use improvement.

Addresses #30 